### PR TITLE
Expose public API token and authorize client requests

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,12 @@ export default function Home() {
   const loadOpenVisits = async () => {
     setLoadingVisits(true);
     try {
-      const res = await fetch('/api/visits/open', { cache: 'no-store' });
+      const res = await fetch('/api/visits/open', {
+        cache: 'no-store',
+        headers: {
+          Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_TOKEN}`,
+        },
+      });
       const json = await parseJsonSafe(res);
       if (json.ok) setOpenVisits(json.data || []);
     } finally {
@@ -61,6 +66,9 @@ export default function Home() {
       const res = await fetch(`/api/lookup/plate/${plate}`, {
         cache: 'no-store',
         signal: controller.signal,
+        headers: {
+          Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_TOKEN}`,
+        },
       });
       clearTimeout(timeout);
       const json = await parseJsonSafe(res);
@@ -110,6 +118,9 @@ export default function Home() {
       const res = await fetch(`/api/visits/${visitId}/checkout`, {
         method: 'POST',
         cache: 'no-store',
+        headers: {
+          Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_TOKEN}`,
+        },
       });
       const json = await parseJsonSafe(res);
       if (!json.ok) {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,7 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  env: {
+    NEXT_PUBLIC_API_TOKEN: process.env.API_TOKEN,
+  },
+};
 export default nextConfig;


### PR DESCRIPTION
## Summary
- expose NEXT_PUBLIC_API_TOKEN mirroring API_TOKEN
- send Authorization header with bearer token on client fetches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4bfca6bac83328377bd934725047d