### PR TITLE
Ensure API requests include auth token

### DIFF
--- a/app/autorizados/page.tsx
+++ b/app/autorizados/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { normalizePlate } from '@/lib/utils';
 import { toast } from 'react-hot-toast';
  
-import { parseJsonSafe } from '@/lib/api';
+import { parseJsonSafe, apiFetch } from '@/lib/api';
 
 import ConfirmDeleteModal from '@/components/ConfirmDeleteModal';
  
@@ -20,7 +20,7 @@ export default function AutorizadosPage() {
   const [confirmId, setConfirmId] = useState<string | null>(null);
 
   const fetchAuthorized = async () => {
-    const res = await fetch('/api/authorized', { cache: 'no-store' });
+    const res = await apiFetch('/api/authorized', { cache: 'no-store' });
     const json = await parseJsonSafe(res).catch(() => null);
     if (res.ok && json?.data) setAuthorized(json.data);
     else toast.error(json?.error || 'Falha ao carregar lista.');
@@ -38,7 +38,7 @@ export default function AutorizadosPage() {
     }
     setLoading(true);
     try {
-      const res = await fetch(editId ? `/api/authorized/${editId}` : '/api/authorized', {
+      const res = await apiFetch(editId ? `/api/authorized/${editId}` : '/api/authorized', {
         method: editId ? 'PUT' : 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -82,7 +82,7 @@ export default function AutorizadosPage() {
 
   const remove = async (id: string) => {
     try {
-      const res = await fetch(`/api/authorized/${id}`, {
+      const res = await apiFetch(`/api/authorized/${id}`, {
         method: 'DELETE',
         cache: 'no-store',
       });

--- a/app/cadastro/page.tsx
+++ b/app/cadastro/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { logError } from '@/lib/utils';
 import { toast } from 'react-hot-toast';
-import { parseJsonSafe } from '@/lib/api';
+import { parseJsonSafe, apiFetch } from '@/lib/api';
 import PersonForm from '@/components/PersonForm';
 import VehicleForm from '@/components/VehicleForm';
 import VehicleCard from '@/components/VehicleCard';
@@ -16,7 +16,7 @@ export default function CadastroPage() {
 
   const loadPeople = async () => {
     try {
-      const res = await fetch('/api/people', { cache: 'no-store' });
+      const res = await apiFetch('/api/people', { cache: 'no-store' });
       const json = await parseJsonSafe<{ data?: Person[] }>(res).catch(() => null);
       if (res.ok && json?.data) setPeople(json.data);
     } catch (e) {
@@ -27,7 +27,7 @@ export default function CadastroPage() {
 
   const loadVehicles = async () => {
     try {
-      const res = await fetch('/api/vehicles', { cache: 'no-store' });
+      const res = await apiFetch('/api/vehicles', { cache: 'no-store' });
       const json = await parseJsonSafe<{ data?: Vehicle[] }>(res).catch(() => null);
       if (res.ok && json?.data) setVehicles(json.data);
     } catch (e) {
@@ -38,7 +38,7 @@ export default function CadastroPage() {
 
   const loadVehiclePeople = async () => {
     try {
-      const res = await fetch('/api/vehicle-people', { cache: 'no-store' });
+      const res = await apiFetch('/api/vehicle-people', { cache: 'no-store' });
       const json = await parseJsonSafe<{ data?: VehiclePerson[] }>(res).catch(() => null);
       if (res.ok && json?.data) {
         const map: Record<string, VehiclePerson[]> = {};

--- a/app/historico/page.tsx
+++ b/app/historico/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { parseJsonSafe } from '@/lib/api';
+import { parseJsonSafe, apiFetch } from '@/lib/api';
 
 type Item = {
   id: string;
@@ -43,7 +43,7 @@ export default function HistoricoPage() {
       const params = new URLSearchParams({
         start, end, page: String(p), pageSize: String(pageSize),
       });
-      const res = await fetch(`/api/visits/history?${params.toString()}`);
+      const res = await apiFetch(`/api/visits/history?${params.toString()}`);
       const json = (await parseJsonSafe(res)) as ApiResp;
       if (!json.ok) {
         alert(json.error || 'Falha ao consultar histórico.');
@@ -64,7 +64,7 @@ export default function HistoricoPage() {
   const onPdfReport = async () => {
     try {
       const params = new URLSearchParams({ start, end });
-      const res = await fetch(`/api/pdf/history?${params.toString()}`, { method: 'POST' });
+      const res = await apiFetch(`/api/pdf/history?${params.toString()}`, { method: 'POST' });
       const json = await parseJsonSafe(res);
       if (!json.ok || !json.url) {
         alert(json.error ?? 'Falha ao gerar relatório');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react';
 import { normalizePlate } from '@/lib/utils';
 import { toast } from 'react-hot-toast';
-import { parseJsonSafe } from '@/lib/api';
+import { parseJsonSafe, apiFetch } from '@/lib/api';
 import OpenVisitsTable, { OpenVisit } from '@/components/OpenVisitsTable';
 import RegisterModal from '@/components/RegisterModal';
 import ConfirmModal from '@/components/ConfirmModal';
@@ -34,7 +34,7 @@ export default function Home() {
     setLoadingVisits(true);
     try {
  
-      const res = await fetch('/api/visits/open', { cache: 'no-store' });
+      const res = await apiFetch('/api/visits/open', { cache: 'no-store' });
       if (res.status === 401) {
         toast.error('Não autorizado');
         return;
@@ -63,12 +63,9 @@ export default function Home() {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);
     try {
-      const res = await fetch(`/api/lookup/plate/${plate}`, {
+      const res = await apiFetch(`/api/lookup/plate/${plate}`, {
         cache: 'no-store',
         signal: controller.signal,
-        headers: {
-          Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_TOKEN}`,
-        },
       });
       clearTimeout(timeout);
       if (res.status === 401) {
@@ -121,12 +118,9 @@ export default function Home() {
     setOpenVisits((prev) => prev.filter((v) => v.id !== visitId));
     let unauthorized = false;
     try {
-      const res = await fetch(`/api/visits/${visitId}/checkout`, {
+      const res = await apiFetch(`/api/visits/${visitId}/checkout`, {
         method: 'POST',
         cache: 'no-store',
-        headers: {
-          Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_TOKEN}`,
-        },
       });
       if (res.status === 401) {
         toast.error('Não autorizado');

--- a/components/ConfirmModal.tsx
+++ b/components/ConfirmModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { parseJsonSafe } from '@/lib/api';
+import { parseJsonSafe, apiFetch } from '@/lib/api';
 import { toast } from 'react-hot-toast';
 
 interface Vehicle {
@@ -37,7 +37,7 @@ export default function ConfirmModal({ vehicle, initialPeople, onClose, onSucces
     }
     setEntering(true);
     try {
-      const resCheck = await fetch('/api/visits/checkin', {
+      const resCheck = await apiFetch('/api/visits/checkin', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/components/EditVehicleModal.tsx
+++ b/components/EditVehicleModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { normalizePlate } from '@/lib/utils';
-import { parseJsonSafe } from '@/lib/api';
+import { parseJsonSafe, apiFetch } from '@/lib/api';
 import { toast } from 'react-hot-toast';
 
 interface Vehicle {
@@ -32,7 +32,7 @@ export default function EditVehicleModal({ vehicle, onClose, onSuccess }: Props)
     }
     setLoading(true);
     try {
-      const res = await fetch(`/api/vehicles/${vehicle.id}`, {
+      const res = await apiFetch(`/api/vehicles/${vehicle.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ plate: p, model: model.trim() || null, color: color.trim() || null }),

--- a/components/PersonForm.tsx
+++ b/components/PersonForm.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { normalizePlate } from '@/lib/utils';
 import { toast } from 'react-hot-toast';
-import { parseJsonSafe } from '@/lib/api';
+import { parseJsonSafe, apiFetch } from '@/lib/api';
 import { Person, Vehicle } from '@/types';
 
 interface Props {
@@ -36,7 +36,7 @@ export default function PersonForm({ vehicles, onSaved }: Props) {
     try {
       let vehicle = vehicles.find((v) => v.plate === nPlate);
       if (!vehicle) {
-        const resVehicle = await fetch('/api/vehicles', {
+        const resVehicle = await apiFetch('/api/vehicles', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -58,7 +58,7 @@ export default function PersonForm({ vehicles, onSaved }: Props) {
         await onSaved();
       }
 
-      const res = await fetch('/api/people', {
+      const res = await apiFetch('/api/people', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/components/RegisterModal.tsx
+++ b/components/RegisterModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { parseJsonSafe } from '@/lib/api';
+import { parseJsonSafe, apiFetch } from '@/lib/api';
 import { toast } from 'react-hot-toast';
 
 interface Props {
@@ -19,7 +19,7 @@ export default function RegisterModal({ plate, onClose, onSuccess }: Props) {
     try {
       let personId: string | null = null;
       if (name.trim()) {
-        const resP = await fetch('/api/people', {
+        const resP = await apiFetch('/api/people', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ full_name: name.trim() }),
@@ -31,7 +31,7 @@ export default function RegisterModal({ plate, onClose, onSuccess }: Props) {
         }
         personId = jsonP.data.id;
       }
-      const resV = await fetch('/api/vehicles', {
+      const resV = await apiFetch('/api/vehicles', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ plate }),
@@ -42,7 +42,7 @@ export default function RegisterModal({ plate, onClose, onSuccess }: Props) {
         return;
       }
       if (personId) {
-        const resLink = await fetch('/api/vehicle-people', {
+        const resLink = await apiFetch('/api/vehicle-people', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ vehicleId: jsonV.data.id, personId }),
@@ -53,7 +53,7 @@ export default function RegisterModal({ plate, onClose, onSuccess }: Props) {
           return;
         }
       }
-      const resC = await fetch('/api/visits/checkin', {
+      const resC = await apiFetch('/api/visits/checkin', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ vehicleId: jsonV.data.id, personId, purpose: 'despacho' }),

--- a/components/VehicleCard.tsx
+++ b/components/VehicleCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { parseJsonSafe } from '@/lib/api';
+import { parseJsonSafe, apiFetch } from '@/lib/api';
 import { toast } from 'react-hot-toast';
  
 import ConfirmDeleteModal from './ConfirmDeleteModal';
@@ -30,7 +30,7 @@ export default function VehicleCard({ vehicle, people, vehiclePeople, onUpdated 
       return;
     }
     try {
-      const res = await fetch('/api/vehicle-people', {
+      const res = await apiFetch('/api/vehicle-people', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ vehicleId: vehicle.id, personId: selection }),
@@ -49,7 +49,7 @@ export default function VehicleCard({ vehicle, people, vehiclePeople, onUpdated 
 
   const unlinkPerson = async (personId: string) => {
     try {
-      const res = await fetch('/api/vehicle-people', {
+      const res = await apiFetch('/api/vehicle-people', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ vehicleId: vehicle.id, personId }),
@@ -68,7 +68,7 @@ export default function VehicleCard({ vehicle, people, vehiclePeople, onUpdated 
   const editVehicle = () => setEditOpen(true);
   const deleteVehicle = async () => {
     try {
-      const res = await fetch(`/api/vehicles/${vehicle.id}`, { method: 'DELETE' });
+      const res = await apiFetch(`/api/vehicles/${vehicle.id}`, { method: 'DELETE' });
       const json = await parseJsonSafe<{ ok?: boolean; error?: string }>(res).catch(() => null);
       if (!res.ok || !json?.ok) {
         toast.error(json?.error || 'Falha ao excluir.');

--- a/components/VehicleForm.tsx
+++ b/components/VehicleForm.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { normalizePlate } from '@/lib/utils';
 import { toast } from 'react-hot-toast';
-import { parseJsonSafe } from '@/lib/api';
+import { parseJsonSafe, apiFetch } from '@/lib/api';
 import { Vehicle } from '@/types';
 
 interface Props {
@@ -24,7 +24,7 @@ export default function VehicleForm({ onSaved }: Props) {
     }
     setLoading(true);
     try {
-      const res = await fetch('/api/vehicles', {
+      const res = await apiFetch('/api/vehicles', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -11,3 +11,12 @@ export async function parseJsonSafe<T = any>(
   }
   return res.json();
 }
+
+export function apiFetch(input: RequestInfo | URL, init: RequestInit = {}) {
+  const headers = new Headers(init.headers as HeadersInit);
+  if (!headers.has('Authorization')) {
+    const token = process.env.NEXT_PUBLIC_API_TOKEN;
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+  }
+  return fetch(input, { ...init, headers });
+}


### PR DESCRIPTION
## Summary
- add apiFetch helper that injects API token in Authorization header
- update client pages and components to use apiFetch, preventing unauthorized responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c39f14688332a6aa23cc185d5bd8