### PR TITLE
Move vehicle and people lists to new pages

### DIFF
--- a/app/cadastro/page.tsx
+++ b/app/cadastro/page.tsx
@@ -6,24 +6,10 @@ import { toast } from 'react-hot-toast';
 import { parseJsonSafe, apiFetch } from '@/lib/api';
 import PersonForm from '@/components/PersonForm';
 import VehicleForm from '@/components/VehicleForm';
-import VehicleCard from '@/components/VehicleCard';
-import { Person, Vehicle, VehiclePerson } from '@/types';
+import { Vehicle } from '@/types';
 
 export default function CadastroPage() {
-  const [people, setPeople] = useState<Person[]>([]);
   const [vehicles, setVehicles] = useState<Vehicle[]>([]);
-  const [vehiclePeople, setVehiclePeople] = useState<Record<string, VehiclePerson[]>>({});
-
-  const loadPeople = async () => {
-    try {
-      const res = await apiFetch('/api/people', { cache: 'no-store' });
-      const json = await parseJsonSafe<{ data?: Person[] }>(res).catch(() => null);
-      if (res.ok && json?.data) setPeople(json.data);
-    } catch (e) {
-      logError('loadPeople', e);
-      toast.error('Falha ao carregar pessoas.');
-    }
-  };
 
   const loadVehicles = async () => {
     try {
@@ -35,88 +21,21 @@ export default function CadastroPage() {
       toast.error('Falha ao carregar veículos.');
     }
   };
-
-  const loadVehiclePeople = async () => {
-    try {
-      const res = await apiFetch('/api/vehicle-people', { cache: 'no-store' });
-      const json = await parseJsonSafe<{ data?: VehiclePerson[] }>(res).catch(() => null);
-      if (res.ok && json?.data) {
-        const map: Record<string, VehiclePerson[]> = {};
-        json.data.forEach((vp) => {
-          if (!map[vp.vehicleId]) map[vp.vehicleId] = [];
-          map[vp.vehicleId].push(vp);
-        });
-        setVehiclePeople(map);
-      }
-    } catch (e) {
-      logError('loadVehiclePeople', e);
-      toast.error('Falha ao carregar vínculos de veículos.');
-    }
-  };
-
   useEffect(() => {
-    loadPeople();
     loadVehicles();
-    loadVehiclePeople();
   }, []);
 
-  const reloadAll = async () => {
-    await loadPeople();
+  const reloadVehicles = async () => {
     await loadVehicles();
-    await loadVehiclePeople();
-  };
-
-  const reloadVehiclesAndLinks = async () => {
-    await loadVehicles();
-    await loadVehiclePeople();
   };
 
   return (
     <div className="space-y-6">
       <h1 className="text-xl font-semibold">Cadastros</h1>
 
-      <PersonForm vehicles={vehicles} onSaved={reloadAll} />
+      <PersonForm vehicles={vehicles} onSaved={reloadVehicles} />
 
-      <VehicleForm onSaved={reloadVehiclesAndLinks} />
-
-      <div className="grid gap-6 md:grid-cols-2">
-        <div className="rounded border bg-white p-4">
-          <h2 className="mb-3 text-lg font-medium">Pessoas cadastradas</h2>
-          {people.length === 0 ? (
-            <p className="text-sm text-gray-500">Nenhuma pessoa cadastrada.</p>
-          ) : (
-            <ul className="divide-y">
-              {people.map((p) => (
-                <li key={p.id} className="py-2 text-sm">
-                  <span className="font-medium">{p.full_name}</span>
-                  {p.doc_number && (
-                    <span className="text-gray-600"> — {p.doc_number}</span>
-                  )}
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-
-        <div className="rounded border bg-white p-4">
-          <h2 className="mb-3 text-lg font-medium">Veículos cadastrados</h2>
-          {vehicles.length === 0 ? (
-            <p className="text-sm text-gray-500">Nenhum veículo cadastrado.</p>
-          ) : (
-            <div className="space-y-4">
-              {vehicles.map((v) => (
-                <VehicleCard
-                  key={v.id}
-                  vehicle={v}
-                  people={people}
-                  vehiclePeople={vehiclePeople[v.id] || []}
-                  onUpdated={reloadVehiclesAndLinks}
-                />
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
+      <VehicleForm onSaved={reloadVehicles} />
     </div>
   );
 }

--- a/app/veiculos/page.tsx
+++ b/app/veiculos/page.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { logError } from '@/lib/utils';
+import { toast } from 'react-hot-toast';
+import { parseJsonSafe, apiFetch } from '@/lib/api';
+import VehicleCard from '@/components/VehicleCard';
+import { Person, Vehicle, VehiclePerson } from '@/types';
+
+export default function VeiculosPage() {
+  const [people, setPeople] = useState<Person[]>([]);
+  const [vehicles, setVehicles] = useState<Vehicle[]>([]);
+  const [vehiclePeople, setVehiclePeople] = useState<Record<string, VehiclePerson[]>>({});
+
+  const loadPeople = async () => {
+    try {
+      const res = await apiFetch('/api/people', { cache: 'no-store' });
+      const json = await parseJsonSafe<{ data?: Person[] }>(res).catch(() => null);
+      if (res.ok && json?.data) setPeople(json.data);
+    } catch (e) {
+      logError('loadPeople', e);
+      toast.error('Falha ao carregar pessoas.');
+    }
+  };
+
+  const loadVehicles = async () => {
+    try {
+      const res = await apiFetch('/api/vehicles', { cache: 'no-store' });
+      const json = await parseJsonSafe<{ data?: Vehicle[] }>(res).catch(() => null);
+      if (res.ok && json?.data) setVehicles(json.data);
+    } catch (e) {
+      logError('loadVehicles', e);
+      toast.error('Falha ao carregar veículos.');
+    }
+  };
+
+  const loadVehiclePeople = async () => {
+    try {
+      const res = await apiFetch('/api/vehicle-people', { cache: 'no-store' });
+      const json = await parseJsonSafe<{ data?: VehiclePerson[] }>(res).catch(() => null);
+      if (res.ok && json?.data) {
+        const map: Record<string, VehiclePerson[]> = {};
+        json.data.forEach((vp) => {
+          if (!map[vp.vehicleId]) map[vp.vehicleId] = [];
+          map[vp.vehicleId].push(vp);
+        });
+        setVehiclePeople(map);
+      }
+    } catch (e) {
+      logError('loadVehiclePeople', e);
+      toast.error('Falha ao carregar vínculos de veículos.');
+    }
+  };
+
+  useEffect(() => {
+    loadPeople();
+    loadVehicles();
+    loadVehiclePeople();
+  }, []);
+
+  const reloadVehiclesAndLinks = async () => {
+    await loadVehicles();
+    await loadVehiclePeople();
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">Veículos</h1>
+      {vehicles.length === 0 ? (
+        <p className="text-sm text-gray-500">Nenhum veículo cadastrado.</p>
+      ) : (
+        <div className="space-y-4">
+          {vehicles.map((v) => (
+            <VehicleCard
+              key={v.id}
+              vehicle={v}
+              people={people}
+              vehiclePeople={vehiclePeople[v.id] || []}
+              onUpdated={reloadVehiclesAndLinks}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/app/visitantes/page.tsx
+++ b/app/visitantes/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { logError } from '@/lib/utils';
+import { toast } from 'react-hot-toast';
+import { parseJsonSafe, apiFetch } from '@/lib/api';
+import { Person } from '@/types';
+
+export default function VisitantesPage() {
+  const [people, setPeople] = useState<Person[]>([]);
+
+  const loadPeople = async () => {
+    try {
+      const res = await apiFetch('/api/people', { cache: 'no-store' });
+      const json = await parseJsonSafe<{ data?: Person[] }>(res).catch(() => null);
+      if (res.ok && json?.data) setPeople(json.data);
+    } catch (e) {
+      logError('loadPeople', e);
+      toast.error('Falha ao carregar pessoas.');
+    }
+  };
+
+  useEffect(() => {
+    loadPeople();
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">Visitantes</h1>
+      {people.length === 0 ? (
+        <p className="text-sm text-gray-500">Nenhuma pessoa cadastrada.</p>
+      ) : (
+        <ul className="divide-y">
+          {people.map((p) => (
+            <li key={p.id} className="py-2 text-sm">
+              <span className="font-medium">{p.full_name}</span>
+              {p.doc_number && <span className="text-gray-600"> — {p.doc_number}</span>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -11,6 +11,8 @@ export default function Nav() {
   const links = [
     { href: "/", label: "Início" },
     { href: "/cadastro", label: "Cadastros" },
+    { href: "/veiculos", label: "Veículos" },
+    { href: "/visitantes", label: "Visitantes" },
     { href: "/autorizados", label: "Autorizados" },
     { href: "/historico", label: "Histórico" },
   ];


### PR DESCRIPTION
## Summary
- add Veículos page listing registered vehicles
- add Visitantes page listing registered people
- simplify Cadastros to contain only forms
- update navigation with links to new pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4caa4a34c833297a335b7e1ba9b08