### PR TITLE
Enhance menu and page layouts

### DIFF
--- a/app/veiculos/page.tsx
+++ b/app/veiculos/page.tsx
@@ -65,11 +65,11 @@ export default function VeiculosPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Veículos</h1>
+      <h1 className="text-2xl font-semibold">Veículos</h1>
       {vehicles.length === 0 ? (
         <p className="text-sm text-gray-500">Nenhum veículo cadastrado.</p>
       ) : (
-        <div className="space-y-4">
+        <div className="grid gap-4 sm:grid-cols-2">
           {vehicles.map((v) => (
             <VehicleCard
               key={v.id}

--- a/app/visitantes/page.tsx
+++ b/app/visitantes/page.tsx
@@ -26,18 +26,20 @@ export default function VisitantesPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-xl font-semibold">Visitantes</h1>
+      <h1 className="text-2xl font-semibold">Visitantes</h1>
       {people.length === 0 ? (
         <p className="text-sm text-gray-500">Nenhuma pessoa cadastrada.</p>
       ) : (
-        <ul className="divide-y">
+        <div className="grid gap-4 sm:grid-cols-2">
           {people.map((p) => (
-            <li key={p.id} className="py-2 text-sm">
-              <span className="font-medium">{p.full_name}</span>
-              {p.doc_number && <span className="text-gray-600"> — {p.doc_number}</span>}
-            </li>
+            <div key={p.id} className="rounded-lg bg-white p-4 shadow">
+              <p className="font-medium">{p.full_name}</p>
+              {p.doc_number && (
+                <p className="text-sm text-gray-600">{p.doc_number}</p>
+              )}
+            </div>
           ))}
-        </ul>
+        </div>
       )}
     </div>
   );

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -25,7 +25,8 @@ export default function Nav() {
           key={href}
           href={href}
           aria-current={active ? "page" : undefined}
-          className={`rounded px-3 py-2 text-sm font-medium transition-colors ${
+          onClick={() => setOpen(false)}
+          className={`block rounded px-3 py-2 text-sm font-medium transition-colors ${
             active ? "bg-white/20" : "hover:bg-white/10"
           }`}
         >
@@ -35,26 +36,37 @@ export default function Nav() {
     });
 
   return (
-    <nav className="bg-gradient-to-r from-blue-600 to-blue-800 text-white shadow">
-      <div className="mx-auto max-w-5xl p-4">
-        <div className="flex items-center justify-between md:justify-center">
+    <>
+      <nav className="bg-gradient-to-r from-blue-600 to-blue-800 text-white shadow">
+        <div className="mx-auto max-w-5xl p-4">
           <button
-            onClick={() => setOpen((v) => !v)}
-            className="space-y-1 md:hidden"
+            onClick={() => setOpen(true)}
+            className="space-y-1"
             aria-label="Abrir menu"
           >
             <span className="block h-0.5 w-6 bg-white"></span>
             <span className="block h-0.5 w-6 bg-white"></span>
             <span className="block h-0.5 w-6 bg-white"></span>
           </button>
-          <div className="hidden gap-6 md:flex">{renderLinks()}</div>
         </div>
-        {open && (
-          <div className="mt-4 flex flex-col items-center gap-4 md:hidden">
-            {renderLinks()}
+      </nav>
+      {open && (
+        <div className="fixed inset-0 z-50 flex">
+          <div className="w-64 bg-gradient-to-b from-blue-600 to-blue-800 p-6 text-white shadow-lg">
+            <div className="mb-6 flex justify-end">
+              <button onClick={() => setOpen(false)} aria-label="Fechar menu">
+                ✕
+              </button>
+            </div>
+            <div className="flex flex-col gap-2">{renderLinks()}</div>
           </div>
-        )}
-      </div>
-    </nav>
+          <div
+            className="flex-1 bg-black/50"
+            onClick={() => setOpen(false)}
+          ></div>
+        </div>
+      )}
+    </>
   );
 }
+

--- a/components/VehicleCard.tsx
+++ b/components/VehicleCard.tsx
@@ -81,11 +81,17 @@ export default function VehicleCard({ vehicle, people, vehiclePeople, onUpdated 
   };
 
   return (
-    <div className="rounded border p-4">
-      <div className="cursor-pointer" onClick={() => setExpanded((v) => !v)}>
-        <span className="font-medium">{vehicle.plate}</span>
-        {vehicle.model && <span className="text-gray-600"> — {vehicle.model}</span>}
-        {vehicle.color && <span className="text-gray-600"> ({vehicle.color})</span>}
+    <div className="rounded-lg bg-white p-4 shadow">
+      <div
+        className="flex cursor-pointer items-center justify-between"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <div>
+          <span className="font-semibold">{vehicle.plate}</span>
+          {vehicle.model && <span className="text-gray-600"> — {vehicle.model}</span>}
+          {vehicle.color && <span className="text-gray-600"> ({vehicle.color})</span>}
+        </div>
+        <span className="text-lg">{expanded ? "−" : "+"}</span>
       </div>
       {expanded && (
         <div className="mt-3 space-y-2">


### PR DESCRIPTION
## Summary
- Replace top navigation with a left overlay menu that closes when selecting a page
- Add grid-based card layouts for vehicles and visitors pages with refreshed styling
- Restyle vehicle cards with clearer expandable sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4cc163b208332b29a4c9a6de8706a