### PR TITLE
Add creation options to vehicles and rename person modals

### DIFF
--- a/app/veiculos/page.tsx
+++ b/app/veiculos/page.tsx
@@ -5,12 +5,17 @@ import { logError } from '@/lib/utils';
 import { toast } from 'react-hot-toast';
 import { parseJsonSafe, apiFetch } from '@/lib/api';
 import VehicleCard from '@/components/VehicleCard';
+import PersonForm from '@/components/PersonForm';
+import VehicleForm from '@/components/VehicleForm';
 import { Person, Vehicle, VehiclePerson } from '@/types';
 
 export default function VeiculosPage() {
   const [people, setPeople] = useState<Person[]>([]);
   const [vehicles, setVehicles] = useState<Vehicle[]>([]);
   const [vehiclePeople, setVehiclePeople] = useState<Record<string, VehiclePerson[]>>({});
+  const [showOptions, setShowOptions] = useState(false);
+  const [showPerson, setShowPerson] = useState(false);
+  const [showVehicle, setShowVehicle] = useState(false);
 
   const loadPeople = async () => {
     try {
@@ -63,9 +68,22 @@ export default function VeiculosPage() {
     await loadVehiclePeople();
   };
 
+  const reloadData = async () => {
+    await loadPeople();
+    await reloadVehiclesAndLinks();
+  };
+
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">Veículos</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Veículos</h1>
+        <button
+          onClick={() => setShowOptions(true)}
+          className="rounded bg-blue-600 px-4 py-2 text-white"
+        >
+          Novo
+        </button>
+      </div>
       {vehicles.length === 0 ? (
         <p className="text-sm text-gray-500">Nenhum veículo cadastrado.</p>
       ) : (
@@ -79,6 +97,83 @@ export default function VeiculosPage() {
               onUpdated={reloadVehiclesAndLinks}
             />
           ))}
+        </div>
+      )}
+
+      {showOptions && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+          <div className="w-80 space-y-3 rounded bg-white p-4">
+            <h2 className="text-lg font-medium">Novo</h2>
+            <button
+              onClick={() => {
+                setShowOptions(false);
+                setShowPerson(true);
+              }}
+              className="w-full rounded bg-blue-600 px-4 py-2 text-white"
+            >
+              Novo Visitante
+            </button>
+            <button
+              onClick={() => {
+                setShowOptions(false);
+                setShowVehicle(true);
+              }}
+              className="w-full rounded bg-green-600 px-4 py-2 text-white"
+            >
+              Novo Veículo
+            </button>
+            <div className="flex justify-end pt-2">
+              <button
+                onClick={() => setShowOptions(false)}
+                className="rounded border px-3 py-2"
+              >
+                Cancelar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showPerson && (
+        <div className="fixed inset-0 overflow-y-auto bg-black/50 p-4">
+          <div className="mx-auto w-full max-w-md">
+            <PersonForm
+              vehicles={vehicles}
+              onSaved={async () => {
+                await reloadData();
+                setShowPerson(false);
+              }}
+            />
+            <div className="mt-2 flex justify-end">
+              <button
+                onClick={() => setShowPerson(false)}
+                className="rounded border bg-white px-4 py-2"
+              >
+                Fechar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showVehicle && (
+        <div className="fixed inset-0 overflow-y-auto bg-black/50 p-4">
+          <div className="mx-auto w-full max-w-md">
+            <VehicleForm
+              onSaved={async () => {
+                await reloadData();
+                setShowVehicle(false);
+              }}
+            />
+            <div className="mt-2 flex justify-end">
+              <button
+                onClick={() => setShowVehicle(false)}
+                className="rounded border bg-white px-4 py-2"
+              >
+                Fechar
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/components/ConfirmModal.tsx
+++ b/components/ConfirmModal.tsx
@@ -32,7 +32,7 @@ export default function ConfirmModal({ vehicle, initialPeople, onClose, onSucces
 
   const onEntryConfirm = async () => {
     if (!selectedPersonId) {
-      toast.error('Selecione uma pessoa vinculada.');
+      toast.error('Selecione um visitante vinculado.');
       return;
     }
     setEntering(true);
@@ -91,7 +91,7 @@ export default function ConfirmModal({ vehicle, initialPeople, onClose, onSucces
               ))}
             </select>
           ) : (
-            <p className="text-sm text-gray-500">Nenhuma pessoa vinculada.</p>
+            <p className="text-sm text-gray-500">Nenhum visitante vinculado.</p>
           )}
         </div>
         <div>

--- a/components/PersonForm.tsx
+++ b/components/PersonForm.tsx
@@ -66,10 +66,10 @@ export default function PersonForm({ vehicles, onSaved }: Props) {
         error?: string;
       }>(res);
       if (!json.ok) {
-        toast.error(json.error || 'Falha ao cadastrar pessoa.');
+        toast.error(json.error || 'Falha ao cadastrar visitante.');
         return;
       }
-      toast.success('Pessoa cadastrada com sucesso!');
+      toast.success('Visitante cadastrado com sucesso!');
       setFullName('');
       setDoc('');
       setNotes('');
@@ -85,7 +85,7 @@ export default function PersonForm({ vehicles, onSaved }: Props) {
 
   return (
     <div className="rounded border bg-white p-4">
-      <h2 className="mb-3 text-lg font-medium">Pessoa</h2>
+      <h2 className="mb-3 text-lg font-medium">Visitante</h2>
       <div className="space-y-3">
         <div>
           <label className="block text-sm">Nome completo *</label>
@@ -126,7 +126,7 @@ export default function PersonForm({ vehicles, onSaved }: Props) {
             className="w-full rounded border px-3 py-2"
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
-            placeholder="Anotações sobre a pessoa"
+            placeholder="Anotações sobre o visitante"
             rows={3}
           />
         </div>
@@ -135,7 +135,7 @@ export default function PersonForm({ vehicles, onSaved }: Props) {
           className="rounded bg-green-600 px-4 py-2 text-white"
           disabled={loading}
         >
-          {loading ? 'Salvando...' : 'Salvar Pessoa'}
+          {loading ? 'Salvando...' : 'Salvar Visitante'}
         </button>
       </div>
     </div>

--- a/components/RegisterModal.tsx
+++ b/components/RegisterModal.tsx
@@ -36,7 +36,7 @@ export default function RegisterModal({ plate, onClose, onSuccess }: Props) {
       });
       const jsonP = await parseJsonSafe(resP);
       if (!jsonP.ok) {
-        toast.error(jsonP.error || 'Falha ao cadastrar pessoa.');
+        toast.error(jsonP.error || 'Falha ao cadastrar visitante.');
         return;
       }
       const personId = jsonP.data.id;
@@ -59,7 +59,7 @@ export default function RegisterModal({ plate, onClose, onSuccess }: Props) {
       });
       const jsonLink = await parseJsonSafe(resLink);
       if (!jsonLink.ok) {
-        toast.error(jsonLink.error || 'Falha ao vincular pessoa.');
+        toast.error(jsonLink.error || 'Falha ao vincular visitante.');
         return;
       }
 


### PR DESCRIPTION
## Summary
- add New button on vehicles page mirroring visitors page
- rename modal text from pessoa to visitante

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4d68d15f88332a0be6fade1da189e