### PR TITLE
Add visitor profile photos with expandable details

### DIFF
--- a/app/api/people/[id]/route.ts
+++ b/app/api/people/[id]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabaseAdmin';
+import env from '@/lib/env';
+import { z } from 'zod';
+import { parseJsonSafe } from '@/lib/api';
+import { getValidationErrorMsg } from '@/lib/validation';
+
+const schema = z.object({
+  photo_url: z.string().url().nullish(),
+});
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const body = await parseJsonSafe(req).catch(() => null);
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { ok: false, error: getValidationErrorMsg(parsed) },
+        { status: 400 }
+      );
+    }
+    const { photo_url } = parsed.data;
+
+    const companyId = env.COMPANY_ID;
+    const supabaseAdmin = getSupabaseAdmin();
+    const { data, error } = await supabaseAdmin
+      .from('people')
+      .update({ photo_url: photo_url || null })
+      .eq('company_id', companyId)
+      .eq('id', params.id)
+      .select('id, full_name, doc_number, phone, email, notes, photo_url')
+      .single();
+    if (error) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ ok: true, data });
+  } catch (e: any) {
+    return NextResponse.json(
+      { ok: false, error: e?.message ?? 'Erro inesperado no servidor.' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/people/route.ts
+++ b/app/api/people/route.ts
@@ -15,6 +15,7 @@ const personSchema = z.object({
   phone: z.string().trim().nullish(),
   email: z.string().trim().nullish(),
   notes: z.string().trim().nullish(),
+  photo_url: z.string().url().nullish(),
 });
 
 export async function GET() {
@@ -23,7 +24,7 @@ export async function GET() {
     const supabaseAdmin = getSupabaseAdmin();
     const { data, error } = await supabaseAdmin
       .from('people')
-      .select('id, full_name, doc_number, phone, email, notes')
+      .select('id, full_name, doc_number, phone, email, notes, photo_url')
       .eq('company_id', companyId)
       .order('full_name');
     if (error) {
@@ -49,7 +50,7 @@ export async function POST(req: Request) {
       );
     }
 
-    const { full_name, doc_number, phone, email, notes } = parsed.data;
+    const { full_name, doc_number, phone, email, notes, photo_url } = parsed.data;
 
     const companyId = env.COMPANY_ID;
     const insert = {
@@ -59,6 +60,7 @@ export async function POST(req: Request) {
       phone: phone || null,
       email: email || null,
       notes: notes || null,
+      photo_url: photo_url || null,
       // se sua tabela tiver defaults para doc_type/doc_country (ex.: 'CPF'/'BR'), deixe que o banco aplique
     };
 

--- a/app/visitantes/page.tsx
+++ b/app/visitantes/page.tsx
@@ -7,6 +7,7 @@ import { parseJsonSafe, apiFetch } from '@/lib/api';
 import PersonForm from '@/components/PersonForm';
 import VehicleForm from '@/components/VehicleForm';
 import { Person, Vehicle } from '@/types';
+import PersonAvatar from '@/components/PersonAvatar';
 
 export default function VisitantesPage() {
   const [people, setPeople] = useState<Person[]>([]);
@@ -14,6 +15,7 @@ export default function VisitantesPage() {
   const [showOptions, setShowOptions] = useState(false);
   const [showPerson, setShowPerson] = useState(false);
   const [showVehicle, setShowVehicle] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const loadPeople = async () => {
     try {
@@ -63,11 +65,22 @@ export default function VisitantesPage() {
       ) : (
         <div className="grid gap-4 sm:grid-cols-2">
           {people.map((p) => (
-            <div key={p.id} className="rounded-lg bg-white p-4 shadow">
-              <p className="font-medium">{p.full_name}</p>
-              {p.doc_number && (
-                <p className="text-sm text-gray-600">{p.doc_number}</p>
-              )}
+            <div
+              key={p.id}
+              className="flex items-center justify-between rounded-lg bg-white p-4 shadow"
+            >
+              <div
+                className="flex-1 cursor-pointer"
+                onClick={() =>
+                  setExpandedId(expandedId === p.id ? null : p.id)
+                }
+              >
+                <p className="font-medium">{p.full_name}</p>
+                {expandedId === p.id && p.doc_number && (
+                  <p className="text-sm text-gray-600">{p.doc_number}</p>
+                )}
+              </div>
+              <PersonAvatar person={p} onUpdated={reloadData} />
             </div>
           ))}
         </div>

--- a/components/PersonAvatar.tsx
+++ b/components/PersonAvatar.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+import { toast } from 'react-hot-toast';
+import { apiFetch, parseJsonSafe } from '@/lib/api';
+import { Person } from '@/types';
+
+interface Props {
+  person: Person;
+  onUpdated: () => Promise<void> | void;
+}
+
+export default function PersonAvatar({ person, onUpdated }: Props) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setLoading(true);
+    try {
+      const ext = file.name.split('.').pop();
+      const filePath = `${person.id}-${Date.now()}.${ext}`;
+      const { error: uploadError } = await supabase.storage
+        .from('people')
+        .upload(filePath, file, { upsert: true });
+      if (uploadError) throw uploadError;
+      const { data } = supabase.storage.from('people').getPublicUrl(filePath);
+      const photoUrl = data.publicUrl;
+      const res = await apiFetch(`/api/people/${person.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ photo_url: photoUrl }),
+      });
+      const json = await parseJsonSafe<{ ok: boolean; error?: string }>(res);
+      if (!json.ok) {
+        toast.error(json.error || 'Falha ao salvar foto.');
+        return;
+      }
+      toast.success('Foto atualizada.');
+      await onUpdated();
+    } catch (err) {
+      console.error(err);
+      toast.error('Falha ao enviar foto.');
+    } finally {
+      setLoading(false);
+      if (fileRef.current) fileRef.current.value = '';
+    }
+  };
+
+  return (
+    <div className="ml-4 flex h-16 w-16 items-center justify-center">
+      {person.photo_url ? (
+        <img
+          src={person.photo_url}
+          alt={person.full_name}
+          className="h-16 w-16 cursor-pointer rounded-full object-cover"
+          onClick={() => !loading && fileRef.current?.click()}
+        />
+      ) : (
+        <div
+          className="flex h-16 w-16 cursor-pointer items-center justify-center rounded-full bg-gray-200 text-2xl text-gray-500"
+          onClick={() => !loading && fileRef.current?.click()}
+        >
+          {loading ? '...' : '+'}
+        </div>
+      )}
+      <input
+        ref={fileRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleFile}
+        disabled={loading}
+      />
+    </div>
+  );
+}

--- a/supabase/migrations/20240724000000_add_people_photo_url.sql
+++ b/supabase/migrations/20240724000000_add_people_photo_url.sql
@@ -1,0 +1,2 @@
+-- Add photo_url column to people table
+ALTER TABLE people ADD COLUMN IF NOT EXISTS photo_url text;

--- a/types/index.ts
+++ b/types/index.ts
@@ -5,6 +5,7 @@ export interface Person {
   phone: string | null;
   email: string | null;
   notes: string | null;
+  photo_url: string | null;
 }
 
 export interface Vehicle {


### PR DESCRIPTION
## Summary
- add `photo_url` column and API support for visitor images
- show only visitor name and expand to reveal document
- allow uploading profile photos for visitors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4d9659f3c8332912d9ddfd13ecb9e