### PR TITLE
fix: avoid supabase crash on visitantes

### DIFF
--- a/components/PersonAvatar.tsx
+++ b/components/PersonAvatar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { supabase } from '@/lib/supabaseClient';
 import { toast } from 'react-hot-toast';
 import { apiFetch, parseJsonSafe } from '@/lib/api';
 import { Person } from '@/types';
@@ -20,6 +19,7 @@ export default function PersonAvatar({ person, onUpdated }: Props) {
     if (!file) return;
     setLoading(true);
     try {
+      const { supabase } = await import('@/lib/supabaseClient');
       const ext = file.name.split('.').pop();
       const filePath = `${person.id}-${Date.now()}.${ext}`;
       const { error: uploadError } = await supabase.storage


### PR DESCRIPTION
## Summary
- dynamically import Supabase client in `PersonAvatar` to prevent env misconfig from blanking the visitors page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4e1c5bb088332be73de32d69d33d2