### PR TITLE
fix: ensure visitor photo uploads correctly

### DIFF
--- a/components/PersonAvatar.tsx
+++ b/components/PersonAvatar.tsx
@@ -24,7 +24,7 @@ export default function PersonAvatar({ person, onUpdated }: Props) {
       const filePath = `${person.id}-${Date.now()}.${ext}`;
       const { error: uploadError } = await supabase.storage
         .from('people')
-        .upload(filePath, file, { upsert: true });
+        .upload(filePath, file, { upsert: true, contentType: file.type });
       if (uploadError) throw uploadError;
       const { data } = supabase.storage.from('people').getPublicUrl(filePath);
       const photoUrl = data.publicUrl;


### PR DESCRIPTION
## Summary
- set explicit content type when uploading visitor photos so Supabase storage accepts the file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4e3d214ec833297fad0f1afe5b0a7