### PR TITLE
fix: handle missing file type when uploading

### DIFF
--- a/components/PersonAvatar.tsx
+++ b/components/PersonAvatar.tsx
@@ -22,9 +22,11 @@ export default function PersonAvatar({ person, onUpdated }: Props) {
       const { supabase } = await import('@/lib/supabaseClient');
       const ext = file.name.split('.').pop();
       const filePath = `${person.id}-${Date.now()}.${ext}`;
+      const options: { upsert: boolean; contentType?: string } = { upsert: true };
+      if (file.type) options.contentType = file.type;
       const { error: uploadError } = await supabase.storage
         .from('people')
-        .upload(filePath, file, { upsert: true, contentType: file.type });
+        .upload(filePath, file, options);
       if (uploadError) throw uploadError;
       const { data } = supabase.storage.from('people').getPublicUrl(filePath);
       const photoUrl = data.publicUrl;


### PR DESCRIPTION
## Summary
- avoid sending empty content type when uploading photos to Supabase storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4e4c0188883329bab2d1c5e306dd4